### PR TITLE
correct URL to always-on box in the "APIC-EM server in this lab" section; minor edits

### DIFF
--- a/labs/basic/1.md
+++ b/labs/basic/1.md
@@ -1,7 +1,7 @@
 # <center>APIC-EM REST API Learning Labs</center>
 # <center>Part I - The Basics<center>
 
-### <font color='red'><b>This Lab is based on the APIC-EM GA release 1.3. The url for API call on DevNet Sanbox is https://devnetapi.cisco.com/sandbox/apic_em</b><br> </font>
+### <font color='red'><b>This Lab is based on the APIC-EM GA release 1.3. The url for API calls to the DevNet Always-On Sandbox is https://devnetapi.cisco.com/sandbox/apic_em</b><br> </font>
 
 ## Getting Started
 
@@ -175,7 +175,7 @@ For reference treatment of all NB REST APIs to the Cisco APIC-EM controller, see
 [Cisco APIC-EM API Reference Docs](http://devnetapic.cisco.com/)
 
 ## APIC-EM server in this lab
-This lab uses the Cisco APIC-EM controller that the [Cisco DevNet Always-On Sandbox](https://developer.cisco.com/site/devnet/sandbox/) provides. To use a different controller, set the **apicem_ip** variable in the **apicem_config.py** file appropriately. For more information, **see** the "Getting Started" section of this lab.
+This lab uses the Cisco APIC-EM controller that the [Cisco DevNet Always-On Sandbox](https://sandboxapic.cisco.com/) provides. To use a different controller, set the **apicem_ip** variable in the **apicem_config.py** file appropriately. For more information, **see** the "Getting Started" section of this lab.
 
 ## Sample scripts
 All Python sample scripts are working in a flat directory. The **apicem\_config.py** is used for configuring parameters in different environment. Those parameters are APIC-EM IP (including port number), username, password and the apic-em API version number. If you are using your own APIC-EM this is the file you need to modify.<br>


### PR DESCRIPTION
just a quick fix - the old url goes off to the reservations page not to the always-on box. 